### PR TITLE
Andlrutt/tkw 27 get tree function

### DIFF
--- a/server/actions/Tree.ts
+++ b/server/actions/Tree.ts
@@ -23,7 +23,7 @@ import { Tree } from "../../utils/types";
 export const getTree = async function(queryTree: Tree) {
     await mongoDB();
     
-    var keys = Object.keys(queryTree);
+    const keys = Object.keys(queryTree);
     
     if (!queryTree || keys.length != 1 || keys[0] != "_id") {
         console.error("Invalid ID");

--- a/server/actions/Tree.ts
+++ b/server/actions/Tree.ts
@@ -17,6 +17,29 @@ import { Tree } from "../../utils/types";
 };
 
 /**
+ * @param queryTree tree object containing only ID of the 
+ * @returns a single tree
+ */
+export const getTree = async function(queryTree: Tree) {
+    await mongoDB();
+    
+    var keys = Object.keys(queryTree);
+    
+    if (!queryTree || keys.length != 1 || keys[0] != "_id") {
+        console.error("Invalid ID");
+        throw new Error("Invalid ID");
+    }
+
+    const tree = await TreeSchema.findById(queryTree);
+    if (!tree) {
+        console.error("Tree not found");
+        throw new Error("Tree not found");
+    }
+
+    return tree;
+}
+
+/**
  * @param id The tree to delete from our database.
  */
 export const deleteTree = async function (id: string) {

--- a/tst/server/Tree.test.ts
+++ b/tst/server/Tree.test.ts
@@ -97,7 +97,8 @@ describe("getTree() tests", () => {
             _id: "test-id1234"
         };
 
-        TreeSchema.findById = jest.fn().mockResolvedValue(undefined);
+        // findById returns null if a tree was not found
+        TreeSchema.findById = jest.fn().mockResolvedValue(null);
         
         expect(getTree(mockQueryTree)).rejects.toThrow("Tree not found");
     });

--- a/tst/server/Tree.test.ts
+++ b/tst/server/Tree.test.ts
@@ -1,7 +1,9 @@
-import { addTree, deleteTree } from "../../server/actions/Tree";
+import { addTree, deleteTree, getTree } from "../../server/actions/Tree";
 import TreeSchema from "../../server/models/Tree";
 import { Tree } from "../../utils/types";
 import mongoose from "mongoose";
+
+jest.mock("server");
 
 describe("addTree() tests", () => {  
     afterAll(() => mongoose.disconnect());
@@ -49,5 +51,70 @@ describe("deleteTree() tests", () => {
         await deleteTree("test-id123");
         expect(TreeSchema.findByIdAndDelete).lastCalledWith("test-id123");
         expect(TreeSchema.findByIdAndDelete).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("getTree() tests", () => {
+    afterAll(() => mongoose.disconnect());
+
+    test("valid call", async () => {
+        const mockQueryTree: Tree = {
+            _id: "test-id123"
+        }
+
+        TreeSchema.findById = jest.fn().mockImplementation(async (tree: Tree) => tree);
+
+        await getTree(mockQueryTree);
+        expect(TreeSchema.findById).lastCalledWith(mockQueryTree);
+        expect(TreeSchema.findById).toHaveBeenCalledTimes(1);
+    });
+
+    test("tree found", async () => {
+        const mockTree: Tree = {
+            _id: "test-id1234",
+            species: "test species",
+            age: 222,
+            coordinates: {
+                latitude: 12345,
+                longitude: 123456,
+            },
+            adopted: true,
+            watering: true,
+            pruning: false,
+        };
+        
+        const mockQueryTree: Tree = {
+            _id: "test-id1234"
+        };
+
+        TreeSchema.findById = jest.fn().mockResolvedValue(mockTree);
+        
+        await expect(getTree(mockQueryTree)).resolves.toEqual(mockTree);
+    });
+
+    test("tree not found", async () => {
+        const mockQueryTree: Tree = {
+            _id: "test-id1234"
+        };
+
+        TreeSchema.findById = jest.fn().mockRejectedValue(new Error("Tree not found"));
+        
+        expect(getTree(mockQueryTree)).rejects.toThrow("Tree not found");
+    });
+    
+    test("invalid query tree", async () => {
+        // query tree contains more than just an ID
+        const mockQueryTree: Tree = {
+            _id: "test-id1234",
+            species: "test species",
+        };
+
+        // query tree does not contain an ID
+        const mockQueryTree2: Tree = {
+            species: "test species",
+        };
+
+        expect(getTree(mockQueryTree)).rejects.toThrow("Invalid ID");
+        expect(getTree(mockQueryTree2)).rejects.toThrow("Invalid ID");
     });
 });

--- a/tst/server/Tree.test.ts
+++ b/tst/server/Tree.test.ts
@@ -97,7 +97,7 @@ describe("getTree() tests", () => {
             _id: "test-id1234"
         };
 
-        TreeSchema.findById = jest.fn().mockRejectedValue(new Error("Tree not found"));
+        TreeSchema.findById = jest.fn().mockResolvedValue(undefined);
         
         expect(getTree(mockQueryTree)).rejects.toThrow("Tree not found");
     });

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -3,9 +3,9 @@ export interface Tree {
     _id?: string;
     species?: string;
     age?: number;
-    coordinates: {
-        latitude: number,
-        longitude: number,
+    coordinates?: {
+        latitude?: number,
+        longitude?: number,
     };
     adopted?: boolean;
     watering?: boolean;


### PR DESCRIPTION
This PR creates the `getTree()` server function and associated tests. It takes a query tree with only an `_id` as a parameter and returns the tree with that `_id`. Please let me know if we want `getTree()`, `deleteTree()`, and `updateTree()` to take a string with the `_id` as a parameter, or continue using the query tree. Please let me know, as I will have to adjust either `getTree()` or `deleteTree()` accordingly for consistency.

In order for a query tree to actually be constructed, I also had to adjust the tree type to make coordinates optional in the tree type.