### PR TITLE
User Table Pagination

### DIFF
--- a/server/actions/User.ts
+++ b/server/actions/User.ts
@@ -6,16 +6,29 @@ import { User } from "utils/types";
  export const getUsers = async function() {
   const axios = require("axios").default;
 
-  const options = {
-    method: 'GET',
-    url: `https://${process.env.AUTH0_DOMAIN}/api/v2/users`,
-    params: {q: 'name:*', search_engine: 'v3'},
-    headers: {authorization: `Bearer ${process.env.AUTH0_MGMT_API_ACCESS_TOKEN}`}
-  };
+  var responseCount = 100;
+  var pageNumber = 0;
+  var allUsers: any[] = [];
 
-  const response = await axios.request(options);
+  // gets all users by continually getting 100 users (max query size) and concating to an array
+  while (responseCount === 100) {
+    const options = {
+      method: 'GET',
+      url: `https://${process.env.AUTH0_DOMAIN}/api/v2/users`,
+      params: {q: 'name:*', search_engine: 'v3', per_page: '100', page: pageNumber},
+      headers: {authorization: `Bearer ${process.env.AUTH0_MGMT_API_ACCESS_TOKEN}`}
+    };
 
-  return response.data;
+    const response = await axios.request(options);
+
+    response.data.map((user: any) => allUsers.push(user));
+
+    pageNumber++;
+
+    responseCount = response.data.length;
+  }
+  
+  return allUsers;
 }
 
 /**


### PR DESCRIPTION
This PR fulfills TKW-55. When rendering the UserTable component, a limitation of the auth0 List Users api is that it can only return 100 users at a time. In the (probably rare) event that we have over 100 users registered, multiple api calls must be made. That is what this PR does. 

While the number of users returned is equal to 100 (there are potentially more users that haven't been returned yet) it makes another api call, this time asking for the next set of 100 users (the next "page"). Tested by asking for 2 users at a time instead of 100. When there were 5 users in auth0, it made 3 calls and returns all of the responses concatenated together, just as expected. 