### PR TITLE
Andlrutt/tkw 58 filter trees seach bar

### DIFF
--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
 import { Tree } from "utils/types";
-import SingleTree from "src/components/SingleTree";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
-import urls from "utils/urls";
 import TreeTable from "src/components/TreeTable";
 
 interface Props {
@@ -12,17 +10,18 @@ interface Props {
 
 const AdminTrees: NextPage<Props> = ({ trees }) => {
 
+    // maintains an array of all trees being displayed
     const [filterTrees, setFilterTrees] = useState(trees);
 
-    
     const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // applies a filter to trees[] based on the current value of the input box
         addFilter(e.target.value)
     }
     
     const addFilter = (query: string) => {
         // if there is a query (input field isn't blank), apply a filter. Otherwise, remove all filters
         if (query) {
-            setFilterTrees(trees.filter((tree) => filter(tree, query)))
+            setFilterTrees(trees.filter((tree) => filter(tree, query)));
         }
         else {
             removeFilter();
@@ -35,7 +34,7 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
     };
 
     const filter = (tree: Tree, query: string) => {
-        return tree.species?.toLowerCase().indexOf(query.toLowerCase()) !== -1
+        return tree.species?.toLowerCase().indexOf(query.toLowerCase()) !== -1;
     }
 
     return (
@@ -46,7 +45,7 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
         <h1>Admin Trees Page</h1>
         
         <div>
-            <input onChange={handleQueryChange} placeholder="Search"></input>
+            <input onChange={handleQueryChange} placeholder="Search by species name"></input>
             <TreeTable trees={filterTrees}/>
         </div>
     </div>

--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Tree } from "utils/types";
 import SingleTree from "src/components/SingleTree";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
 import urls from "utils/urls";
 import TreeTable from "src/components/TreeTable";
-import { MdOutlineSort, MdWatchLater } from "react-icons/md"
 
 interface Props {
     trees: Tree[],
@@ -13,10 +12,31 @@ interface Props {
 
 const AdminTrees: NextPage<Props> = ({ trees }) => {
 
-    // reroutes to specific tree page
-    const onClick = (treeId: string) => {
-        window.location.replace(urls.pages.updateTree(treeId));
+    const [filterTrees, setFilterTrees] = useState(trees);
+
+    
+    const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        addFilter(e.target.value)
+    }
+    
+    const addFilter = (query: string) => {
+        // if there is a query (input field isn't blank), apply a filter. Otherwise, remove all filters
+        if (query) {
+            setFilterTrees(trees.filter((tree) => filter(tree, query)))
+        }
+        else {
+            removeFilter();
+        }
+    }
+
+    const removeFilter = () => {
+        // trees[] holds all trees in the database, so this removes any filters
+        setFilterTrees(trees);
     };
+
+    const filter = (tree: Tree, query: string) => {
+        return tree.species?.toLowerCase().indexOf(query.toLowerCase()) !== -1
+    }
 
     return (
     <div>    
@@ -26,7 +46,8 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
         <h1>Admin Trees Page</h1>
         
         <div>
-            <TreeTable trees={trees}/>
+            <input onChange={handleQueryChange} placeholder="Search"></input>
+            <TreeTable trees={filterTrees}/>
         </div>
     </div>
     );


### PR DESCRIPTION
This PR fulfills TKW-58, adding a search bar the admin trees table. Nothing crazy here. There is a basic search bar where you can input a query. Whenever the query changes, a (case-insensitive) filter is applied to the array of trees that the `TreeTable` component takes as a prop, and any tree species that matches the query is displayed on the table.

Here's a quick demonstration, nothing fancy.
![Admin Trees _ Trees Knoxville](https://user-images.githubusercontent.com/71574118/162257974-cc57d360-4b09-48ff-93c2-c920c980515d.gif)

I held off on frontend pending a finalized design.
Down the line, there will be filtering by age and date, but that is a separate task (TKW-61).