### PR TITLE
Andlrutt/tkw 66 user search bar

### DIFF
--- a/src/components/UserTable/index.tsx
+++ b/src/components/UserTable/index.tsx
@@ -7,7 +7,7 @@ import urls from "utils/urls";
 
 
 interface Props {
-    users: [];
+    users: User[];
 }
 
 const UserTable: NextPage<Props> = ({ users }) => {

--- a/src/pages/admin/users/index.tsx
+++ b/src/pages/admin/users/index.tsx
@@ -1,13 +1,43 @@
-import React from "react";
+import React, { useState } from "react";
 import { GetStaticPropsContext, NextPage } from "next";
 import UserTable from "src/components/UserTable";
 import { getUsers } from "server/actions/User";
+import { User } from "utils/types";
 
 interface Props {
-    users: [],
+    users: User[],
 }
 
 const AdminUsers: NextPage<Props> = ({ users }) => {
+
+    // maintains an array of all users being displayed
+    const [filterUsers, setFilterUsers] = useState(users);
+
+    const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // applies a filter to users[] based on the current value of the input box
+        addFilter(e.target.value)
+    }
+
+    const addFilter = (query: string) => {
+        // if there is a query (input field isn't blank), apply a filter. Otherwise, remove all filters
+        if (query) {
+            setFilterUsers(users.filter((user) => filter(user, query)));
+        }
+        else {
+            removeFilter();
+        }
+    }
+
+    const filter = (user: User, query: string) => {
+        return (user.name?.toLowerCase().indexOf(query.toLowerCase()) !== -1  ||
+                user.email?.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                user.user_metadata?.phone?.toLowerCase().indexOf(query.toLowerCase()) !== -1);
+    }
+
+    const removeFilter = () => {
+        // users[] holds all trees in the database, so this removes any filters
+        setFilterUsers(users);
+    };
 
     return (
     <div>    
@@ -17,7 +47,8 @@ const AdminUsers: NextPage<Props> = ({ users }) => {
         <h1>Admin Users Page</h1>
         
         <div>
-            <UserTable users={users}/>
+            <input onChange={handleQueryChange} placeholder="Search"></input>
+            <UserTable users={filterUsers}/>
         </div>
     </div>
     );

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -7,11 +7,6 @@ export interface Tree {
         latitude?: string,
         longitude?: string,
     };
-    image?: {
-        assetID?: string;
-        url?: string;
-        _id?: string;
-    }
     adopted?: boolean;
     watering?: boolean;
     pruning?: boolean;


### PR DESCRIPTION
This PR fulfills TKW-66, adding a search bar to the admin user table. Very similar to TKW-58, which added a search bar to the trees table. Only difference here is that when a search query is entered, all three elements of the table are checked, so that the single search box can be used to search for a user by name, email, or phone number. The GIF below is a demonstration of that. I find the user with the name "Andrew Rutter" in three different ways.
![Admin Trees _ Trees Knoxville (1)](https://user-images.githubusercontent.com/71574118/162799765-c2de89c3-f904-4fe1-8c52-3f1f6b90b3f6.gif)

To do this, there was some minor tweaking to some interfaces on some components. Just changed the props to be an array of users instead of just an array.

Not sure where it was sourced from, but there was also a duplicate `image` field for a Tree in `utils/types`. An `image` was being defined as both an object with custom properties and as a `ContentfulImage` object. I removed the one with custom properties. Let me know if this was done in error.