### PR TITLE
Andlrutt/tkw 61 filter trees table

### DIFF
--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { Tree } from "utils/types";
-import SingleTree from "src/components/SingleTree";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
 import urls from "utils/urls";
 import TreeTable from "src/components/TreeTable";
-import { MdOutlineSort, MdWatchLater } from "react-icons/md"
 
 interface Props {
     trees: Tree[],
@@ -13,18 +11,19 @@ interface Props {
 
 const AdminTrees: NextPage<Props> = ({ trees }) => {
 
-    // reroutes to specific tree page
-    const onClick = (treeId: string) => {
-        window.location.replace(urls.pages.updateTree(treeId));
-    };
-
     return (
     <div>    
         <head>
             <title>Admin Trees | Trees Knoxville</title>
         </head>
         <h1>Admin Trees Page</h1>
-        
+        <div>
+            <select name="filterType">
+                <option value="none" selected>-- Filter by --</option>
+                <option value="age">Age</option>
+                <option value="date">Date</option>
+            </select>
+        </div>
         <div>
             <TreeTable trees={trees}/>
         </div>

--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Tree } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
-import urls from "utils/urls";
 import TreeTable from "src/components/TreeTable";
 
 interface Props {
@@ -11,6 +10,21 @@ interface Props {
 
 const AdminTrees: NextPage<Props> = ({ trees }) => {
 
+    const handleDropdownChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const filterType = e.target.value;
+        if (filterType === "age") {
+
+        }
+        else if (filterType === "date") {
+
+        }
+        // removes filter and clears age and date input fields
+        else {
+
+        }
+    };
+
+
     return (
     <div>    
         <head>
@@ -18,11 +32,17 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
         </head>
         <h1>Admin Trees Page</h1>
         <div>
-            <select name="filterType">
-                <option value="none" selected>-- Filter by --</option>
+            <select onChange={handleDropdownChange} name="filterType">
+                <option value="none" selected>--- Filter by ---</option>
                 <option value="age">Age</option>
                 <option value="date">Date</option>
             </select>
+
+            <input type="number" placeholder="start age"></input>
+            <input type="number" placeholder="end age"></input>
+
+            <input type="date"></input>
+            <input type="date"></input>
         </div>
         <div>
             <TreeTable trees={trees}/>

--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -4,6 +4,16 @@ import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
 import TreeTable from "src/components/TreeTable";
 
+
+interface stateInterface {
+    filterType: string,
+    minAge: number,
+    maxAge: number,
+    minDate: Date,
+    maxDate: Date,
+    speciesName: string,
+}
+
 interface Props {
     trees: Tree[],
 }
@@ -11,46 +21,89 @@ interface Props {
 const AdminTrees: NextPage<Props> = ({ trees }) => {
 
     const handleDropdownChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const filterType = e.target.value;
-        if (filterType === "age") {
-
+        if (e.target.value === "none") {
+            // empty out those input containers!
         }
-        else if (filterType === "date") {
 
-        }
-        // removes filter and clears age and date input fields
-        else {
-
-        }
+        values.filterType = e.target.value;
     };
 
     // maintains an array of all trees being displayed
     const [filterTrees, setFilterTrees] = useState(trees);
+    const [values, setValues] = React.useState<stateInterface>({} as stateInterface);
+    
 
-    const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        // applies a filter to trees[] based on the current value of the input box
-        addFilter(e.target.value)
-    }
-
-    const addFilter = (query: string) => {
+    const addSpeciesFilter = (speciesName: string) => {
         // if there is a query (input field isn't blank), apply a filter. Otherwise, remove all filters
-        if (query) {
-            setFilterTrees(trees.filter((tree) => filter(tree, query)));
+        if (speciesName) {
+            setFilterTrees(trees.filter((tree) => speciesFilter(tree, speciesName)));
         }
         else {
             removeFilter();
         }
     }
 
+    const addAgeFilter = (minAge: number, maxAge: number, speciesName: string) => {
+        setFilterTrees(trees.filter((tree) => ageFilter(tree, minAge, maxAge, speciesName)));
+    };
+
+    const addDateFilter = (minDate: Date, maxDate: Date, speciesName: string) => {
+        setFilterTrees(trees.filter((tree) => dateFilter(tree, minDate, maxDate, speciesName)));
+    };
+
+    const speciesFilter = (tree: Tree, speciesName: string) => {
+        return tree?.species?.toLowerCase().indexOf(speciesName.toLowerCase()) !== -1;
+    };
+
+    const ageFilter = (tree: Tree, minAge: number, maxAge: number, speciesName: string) => {
+        return tree?.age! >= minAge && tree?.age! <= maxAge && speciesFilter(tree, speciesName);
+    };
+
+    const dateFilter = (tree: Tree, minDate: Date, maxDate: Date, speciesName: string) => {
+        // something with this date comparison...
+        return new Date(tree?.datePlanted!) >= minDate && new Date(tree?.datePlanted!) <= maxDate && speciesFilter(tree, speciesName)
+    };
+
     const removeFilter = () => {
         // trees[] holds all trees in the database, so this removes any filters
         setFilterTrees(trees);
     };
 
-    const filter = (tree: Tree, query: string) => {
-        return tree.species?.toLowerCase().indexOf(query.toLowerCase()) !== -1;
-    }
 
+    const onChange = (event: React.SyntheticEvent) => {
+        event.persist();
+        const target = event.target as HTMLInputElement;
+        setValues(values => ({...values, [target.name]: target.value}));
+        
+        
+        
+        if (values.filterType === "age") {
+            if (target.name === "minAge") {
+                addAgeFilter(Number(target.value), values.maxAge || 1000, values.speciesName);
+            }
+            else if (target.name === "maxAge") {
+                addAgeFilter(values.minAge, Number(target.value) || 1000, values.speciesName);
+            }
+            else {
+                addAgeFilter(values.minAge, values.maxAge || 1000, target.value);
+            }
+        }
+        else if (values.filterType === "date") {
+            if (target.name === "minDate") {
+                addDateFilter(new Date(target.value) || 0, values.maxDate || new Date(), values.speciesName) ;
+            }
+            else if (target.name === "maxDate") {
+                addDateFilter(values.minDate || 0, new Date(target.value) || new Date(), values.speciesName);
+            }
+            else {
+                addDateFilter(values.minDate || 0, values.maxDate || new Date(), target.value);
+            }
+        }
+        else {
+            // species name changed, and no other filters should be applied
+            addSpeciesFilter(target.value);
+        }
+    }
 
     return (
     <div>    
@@ -65,14 +118,14 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
                 <option value="date">Date</option>
             </select>
 
-            <input type="number" placeholder="start age"></input>
-            <input type="number" placeholder="end age"></input>
+            <input name="minAge" type="number" placeholder="start age" onChange={onChange}></input>
+            <input name="maxAge" type="number" placeholder="end age" onChange={onChange}></input>
 
-            <input type="date"></input>
-            <input type="date"></input>
+            <input type="date" onChange={onChange}></input>
+            <input type="date" onChange={onChange}></input>
         </div>
         <div>
-            <input onChange={handleQueryChange} placeholder="Search by species name"></input>
+            <input name="speciesName" placeholder="Search by species name" onChange={onChange}></input>
             <TreeTable trees={filterTrees}/>
         </div>
     </div>

--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -80,7 +80,7 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
         addSpeciesFilter(values.speciesName);
 
         // updates the filter type (age, date, or none)
-        values.filterType = e.target.value;
+        setValues(values => ({...values, [e.target.name]: e.target.value}));
     };
 
     // called when any input field changes

--- a/src/pages/admin/trees/index.tsx
+++ b/src/pages/admin/trees/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Tree } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
 import { getTrees } from "server/actions/Tree";
@@ -24,6 +24,33 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
         }
     };
 
+    // maintains an array of all trees being displayed
+    const [filterTrees, setFilterTrees] = useState(trees);
+
+    const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // applies a filter to trees[] based on the current value of the input box
+        addFilter(e.target.value)
+    }
+
+    const addFilter = (query: string) => {
+        // if there is a query (input field isn't blank), apply a filter. Otherwise, remove all filters
+        if (query) {
+            setFilterTrees(trees.filter((tree) => filter(tree, query)));
+        }
+        else {
+            removeFilter();
+        }
+    }
+
+    const removeFilter = () => {
+        // trees[] holds all trees in the database, so this removes any filters
+        setFilterTrees(trees);
+    };
+
+    const filter = (tree: Tree, query: string) => {
+        return tree.species?.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+    }
+
 
     return (
     <div>    
@@ -45,7 +72,8 @@ const AdminTrees: NextPage<Props> = ({ trees }) => {
             <input type="date"></input>
         </div>
         <div>
-            <TreeTable trees={trees}/>
+            <input onChange={handleQueryChange} placeholder="Search by species name"></input>
+            <TreeTable trees={filterTrees}/>
         </div>
     </div>
     );


### PR DESCRIPTION
This is an extension of TKW-58, filtering trees by species name. Since this just takes that code and adds directly to it, I've closed the PR I had up for it since it would have immediately been overwritten by this PR. [Here](https://github.com/hack4impact-utk/trees-knoxville/pull/27) is the PR for TKW-58 if you would like to reference it.

This PR fulfills TKW-61, filtering the tree table based on age and date (on top of filtering by species name, which is what the above pull request is for).

Accomplishing this was difficult, there were a lot of things that made it more complicated than it would seem: An age/date filter was conditionally applied, but a species name filter was always applied, `stateinterface` values aren't immediately available for use after updating them, there were a lot of edge cases if an input field was empty, etc. A lot of things to work out. I've done my best to comment the code well, please let me know if there is anything I can clarify in terms of what is going on or why I did something the way I did.

Basically, whenever an input value is changed, a new filter is applied. The search bar for species is always displayed/applied, but there is a dropdown to select if you also want to filter by age or date. Take a look below to see exactly what's going on. In the video, the ages of the three trees displayed from top to bottom are 5, 10, and 15, respectively (also labeled in their location for convenience), and their date planted is visible. I go through all use cases to show how it works.

https://user-images.githubusercontent.com/71574118/163264703-a04ba54d-eb4a-4166-9c2d-6ed3346164bf.mp4

I held off on doing the frontend for this, pending a redesign of the whole tree table page.